### PR TITLE
`Update run-tests.yml to use pytest instead of unittest discover`

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Run unittests
         run: |
-          python -m unittest discover -s tests
+          pytest
 
   merge-code:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update CI workflow to use pytest instead of unittest discover for running tests.