### PR TITLE
Remove event parameter from handleAuthToggle function

### DIFF
--- a/frontend/web/src/components/Pages/AuthPage/AuthPage.js
+++ b/frontend/web/src/components/Pages/AuthPage/AuthPage.js
@@ -7,8 +7,7 @@ function AuthLogin({ toggleToRegister }) {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
 
-  const handleAuthToggle = (e) => {
-    e.preventDefault();
+  const handleAuthToggle = () => {
     console.log("Auth toggle clicked");
     toggleToRegister("register");
   };


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Remove the `e` parameter and  `e.preventDefault()` call from the `handleAuthToggle` function.